### PR TITLE
Fixes for your profdata support

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,7 @@
 require "bundler/gem_tasks"
+
+desc 'Execute tests'
+task :spec do
+  sh 'bundle exec rspec spec'
+end
+

--- a/bin/slather
+++ b/bin/slather
@@ -120,8 +120,15 @@ Clamp do
 
     parameter "[xcodeproj]", "Path to the xcodeproj", :attribute_name => :xcodeproj_path
 
+    option ["--input-format"], "INPUT_FORMAT", "Input format (gcov, profdata)"
+
     def execute
-      project = Slather::Project.open(xcodeproj_path)
+      xcodeproj_path_to_open = xcodeproj_path || Slather::Project.yml["xcodeproj"]
+      unless xcodeproj_path_to_open
+        raise StandardError, "Must provide an xcodeproj through .slather.yml"
+      end
+      project = Slather::Project.open(xcodeproj_path_to_open)
+      project.input_format = input_format
       project.setup_for_coverage
       project.save
     end

--- a/bin/slather
+++ b/bin/slather
@@ -120,7 +120,7 @@ Clamp do
 
     parameter "[xcodeproj]", "Path to the xcodeproj", :attribute_name => :xcodeproj_path
 
-    option ["--input-format"], "INPUT_FORMAT", "Input format (gcov, profdata)"
+    option ["--format"], "FORMAT", "Type of coverage to use (gcov, clang, auto)"
 
     def execute
       xcodeproj_path_to_open = xcodeproj_path || Slather::Project.yml["xcodeproj"]
@@ -128,8 +128,7 @@ Clamp do
         raise StandardError, "Must provide an xcodeproj through .slather.yml"
       end
       project = Slather::Project.open(xcodeproj_path_to_open)
-      project.input_format = input_format
-      project.setup_for_coverage
+      project.setup_for_coverage(format ? format.to_sym : :auto)
       project.save
     end
 

--- a/lib/slather.rb
+++ b/lib/slather.rb
@@ -19,4 +19,10 @@ module Slather
     Pod::UI.warn("[Slather] prepare_pods is now deprecated. The call to prepare_pods in your Podfile can simply be ommitted.")
   end
 
+  def self.xcode_version
+    xcode_path = `xcode-select -p`.strip
+    xcode_version = `mdls -name kMDItemVersion -raw #{xcode_path.shellescape}/../..`.strip
+    xcode_version.split('.').map(&:to_i)
+  end
+
 end

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -2,6 +2,7 @@ require 'fileutils'
 require 'xcodeproj'
 require 'json'
 require 'yaml'
+require 'shellwords'
 
 module Xcodeproj
   class Project
@@ -111,8 +112,9 @@ module Slather
         raise StandardError, "No Coverage.profdata files found. Please make sure the \"Code Coverage\" checkbox is enabled in your scheme's Test action or the build_directory property is set."
       end
       xcode_path = `xcode-select -p`.strip
-      llvm_cov_command = File.join(xcode_path, "Toolchains/XcodeDefault.xctoolchain/usr/bin/llvm-cov show -instr-profile #{coverage_profdata} #{binary_file}")
-      `#{llvm_cov_command}`
+      llvm_cov_path = File.join(xcode_path, "Toolchains/XcodeDefault.xctoolchain/usr/bin/llvm-cov")
+      llvm_cov_args = %W(show -instr-profile #{coverage_profdata} #{binary_file})
+      `#{llvm_cov_path.shellescape} #{llvm_cov_args.shelljoin}`
     end
     private :profdata_llvm_cov_output
 

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -141,10 +141,8 @@ module Slather
       if profdata_coverage_dir == nil || (coverage_profdata = Dir["#{profdata_coverage_dir}/**/Coverage.profdata"].first) == nil
         raise StandardError, "No Coverage.profdata files found. Please make sure the \"Code Coverage\" checkbox is enabled in your scheme's Test action or the build_directory property is set."
       end
-      xcode_path = `xcode-select -p`.strip
-      llvm_cov_path = File.join(xcode_path, "Toolchains/XcodeDefault.xctoolchain/usr/bin/llvm-cov")
       llvm_cov_args = %W(show -instr-profile #{coverage_profdata} #{binary_file})
-      `#{llvm_cov_path.shellescape} #{llvm_cov_args.shelljoin}`
+      `xcrun llvm-cov #{llvm_cov_args.shelljoin}`
     end
     private :profdata_llvm_cov_output
 

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -7,10 +7,15 @@ require 'shellwords'
 module Xcodeproj
   class Project
 
-    def slather_setup_for_coverage
+    def slather_setup_for_coverage(input_format = "gcov")
       build_configurations.each do |build_configuration|
         build_configuration.build_settings["GCC_INSTRUMENT_PROGRAM_FLOW_ARCS"] = "YES"
-        build_configuration.build_settings["GCC_GENERATE_TEST_COVERAGE_FILES"] = "YES"
+        if input_format == "profdata"
+          build_configuration.build_settings["CLANG_ENABLE_CODE_COVERAGE"] = "YES"
+          # @todo also activate codeCoverageEnabled = "YES" in every xcscheme's TestAction
+        else
+          build_configuration.build_settings["GCC_GENERATE_TEST_COVERAGE_FILES"] = "YES"
+        end
       end
     end
 
@@ -22,7 +27,9 @@ module Slather
 
     attr_accessor :build_directory, :ignore_list, :ci_service, :coverage_service, :coverage_access_token, :source_directory, :output_directory, :xcodeproj, :show_html, :input_format, :scheme
 
-    alias_method :setup_for_coverage, :slather_setup_for_coverage
+    def setup_for_coverage
+      slather_setup_for_coverage(self.input_format)
+    end
 
     def self.open(xcodeproj)
       proj = super


### PR DESCRIPTION
This PR:

* Fixes escaping of Xcode path
* Ensures `slather setup` was passed an xcodeproj argument
* adds an `--input-format` option to `slather setup` too so that it injects `CLANG_ENABLE_CODE_COVERAGE` instead of `GCC_GENERATE_TEST_COVERAGE_FILES`
* prepare the code to update the xcschemes in order to auto-activate "Gather coverage data"

---

Note that modifying the xcscheme files will need CocoaPods/Xcodeproj#288 which was included in xcodeproj 0.27 and above, so we'll need to bump the dependency on `xcodeproj` up to `~> 0.27.0` to be able to use this.  
Since bumping the `xcodeproj` dependency will also requires us to bump the dependency on the `cocoapods` gem as well, it seemed like a big change with potential repercussions so I stopped my implementation here (the code using Xcodeproj 0.27 has successfully been tested on a sample project though and works with `xcodeproj-0.27.3`).

So I thought maybe we should keep that version bump for a separate PR for later, so we can have a first version supporting profdata first that only warns the user about having to activate "Gather coverage data" manually in the meantime.

\cc @mattdelves @marklarr